### PR TITLE
Fix some typos in the unlearning notebook

### DIFF
--- a/unlearning-CIFAR10.ipynb
+++ b/unlearning-CIFAR10.ipynb
@@ -25,7 +25,7 @@
     "  * 🏅 In the third section we'll score our unlearning algorithm using a simple membership inference attacks (MIA). Note that this is a different evaluation than the one that will be used in the competition's submission.\n",
     "  \n",
     "\n",
-    "We emphasize that this notebook is provided for convenience so help participants quickly get started. Submissions will be scored using a different method than the one provided in this notebook on a different (private) dataset of human faces. To run the notebook, the requirements is having installed an up-to-date version of Python and Pytorch."
+    "We emphasize that this notebook is provided for convenience to help participants quickly get started. Submissions will be scored using a different method than the one provided in this notebook on a different (private) dataset of human faces. To run the notebook, the requirement is to have installed an up-to-date version of Python and Pytorch."
    ]
   },
   {
@@ -75,7 +75,7 @@
    "source": [
     "# 💾 Download dataset and pre-trained model\n",
     "\n",
-    "In this section we'll load a sample dataset (CIFAR-10), a pre-trained model (ResNet18) trained on CIFAR-10, plot some images and compute the accuracy of the model on the test set."
+    "In this section, we'll load a sample dataset (CIFAR-10), a pre-trained model (ResNet18) trained on CIFAR-10, plot some images and compute the accuracy of the model on the test set."
    ]
   },
   {
@@ -257,7 +257,7 @@
     "\n",
     "In this section we develop the unlearning algorithm.\n",
     "\n",
-    "We start by splitting the original training set into a retain set and a forget set. Typically, the retain set is much later than the forget set. Here, we produce a split that is 10% forget set, 90% retain set."
+    "We start by splitting the original training set into a retain set and a forget set. Typically, the retain set is much larger than the forget set. Here, we produce a split that is 10% forget set, and 90% retain set."
    ]
   },
   {
@@ -285,7 +285,7 @@
    "source": [
     "The goal of an unlearning algorithm is to produce a model that approximates as much as possible the model trained solely on the retain set.\n",
     "\n",
-    "Below is a simple unlearning algorithms provided for illustration purposes. We call this algorithm _unlearning by fine-tuning_. It starts from the pre-trained and optimizes for a few epochs on the retain set. This is a very simple unlearning algorithm, but it is not very computationally efficient.\n",
+    "Below is a simple unlearning algorithm provided for illustration purposes. We call this algorithm _unlearning by fine-tuning_. It starts from the pre-trained and optimizes for a few epochs on the retain set. This is a very simple unlearning algorithm, but it is not very computationally efficient.\n",
     "\n",
     "To make a new entry in the competitions, participants will submit an unlearning function with the same API as the one below. Note that the unlearning function takes as input a pre-trained model, a retain set, a forget set and an evaluation set (even though the fine-tuning algorithm below only uses the retain set and ignores the other datasets)."
    ]
@@ -394,7 +394,7 @@
    "source": [
     "# 🏅 Evaluation\n",
     "\n",
-    "In this section we'll quantify the quality of the unlearning algorithm through a simple membership inference attack (MIA). We provide this simple MIA for convenience, so that participants can quickly obtain a metric for their unlearning algorithm,but submissions will be scored using a different method.\n",
+    "In this section, we'll quantify the quality of the unlearning algorithm through a simple membership inference attack (MIA). We provide this simple MIA for convenience so that participants can quickly obtain a metric for their unlearning algorithm, but submissions will be scored using a different method.\n",
     "\n",
     "This MIA consists of a [logistic regression model](https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression) that predicts whether the model was trained on a particular sample from that sample's loss. To get an idea on the difficulty of this problem, we first plot below a histogram of the losses of the pre-trained model on the train and test set"
    ]
@@ -617,7 +617,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the score above, the MIA is indeed less accurate on the unlearned model than on the original model, as expected. Finally, we'll plot the histogram of losses of the unlearned model on the train and test set. From the below figure, we can observe that the distributions of forget and test losses are more similar under the unlearned model compare to the original model, as expected."
+    "From the score above, the MIA is indeed less accurate on the unlearned model than on the original model, as expected. Finally, we'll plot the histogram of losses of the unlearned model on the train and test set. From the below figure, we can observe that the distributions of forget and test losses are more similar under the unlearned model compared to the original model, as expected."
    ]
   },
   {


### PR DESCRIPTION
Fixed some typos in the unlearning notebook. Ex: 

### Before

> Typically, the retain set is much "later" than the forget set.

### After 

> Typically, the retain set is much "larger" than the forget set.