### PR TITLE
Print accuracy on retain and forget sets instead of the training set

### DIFF
--- a/unlearning-CIFAR10.ipynb
+++ b/unlearning-CIFAR10.ipynb
@@ -266,7 +266,8 @@
         "    return correct / total\n",
         "\n",
         "\n",
-        "print(f\"Train set accuracy: {100.0 * accuracy(model, train_loader):0.1f}%\")\n",
+        "print(f\"Retain set accuracy: {100.0 * accuracy(model, retain_loader):0.1f}%\")\n",
+        "print(f\"Forget set accuracy: {100.0 * accuracy(model, forget_loader):0.1f}%\")\n",
         "print(f\"Test set accuracy: {100.0 * accuracy(model, test_loader):0.1f}%\")"
       ]
     },
@@ -392,6 +393,7 @@
       ],
       "source": [
         "print(f\"Retain set accuracy: {100.0 * accuracy(ft_model, retain_loader):0.1f}%\")\n",
+        "print(f\"Forget set accuracy: {100.0 * accuracy(ft_model, forget_loader):0.1f}%\")\n",
         "print(f\"Test set accuracy: {100.0 * accuracy(ft_model, test_loader):0.1f}%\")"
       ]
     },


### PR DESCRIPTION
In the context of the Unlearning Challenge, printing accuracy for the retain and forget sets is more appropriate instead of printing the accuracy for the overall Training set. For now, I have just modified the code part and have not run the Jupyter notebook which updates the output cells too.